### PR TITLE
Fix: Initialize and run Axum server and configure application port.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -14,12 +14,17 @@ impl Config {
         let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
         let jwt_secret = std::env::var("JWT_SECRET_KEY").expect("JWT_SECRET_KEY must be set");
         let jwt_maxage = std::env::var("JWT_MAXAGE").expect("JWT_MAXAGE must be set");
+        let port_str = std::env::var("APP_PORT");
+        let port = match port_str {
+            Ok(val) => val.parse::<u16>().unwrap_or(3000),
+            Err(_) => 3000,
+        };
 
         Config {
             database_url: (database_url),
             jwt_secret: (jwt_secret),
             jwt_maxage: (jwt_maxage.parse::<i16>().unwrap()),
-            port: (5432),
+            port,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,46 @@
+use axum::Server;
+use sqlx::postgres::PgPoolOptions;
+use std::{net::SocketAddr, sync::Arc};
 mod config;
-mod models;
+mod db;
 mod dtos;
 mod errors;
-mod db;
+mod handler;
+mod middleware;
+mod models;
 mod router;
-fn main() {
-    println!("Hello, world!");
+mod utils;
+
+use config::Config;
+use db::DBClient;
+use router::create_router;
+
+pub struct AppState {
+    db: DBClient,
+    config: Config,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = Config::init();
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&config.database_url)
+        .await?;
+    let db_client = DBClient::new(pool);
+
+    let app_state = Arc::new(AppState {
+        db: db_client,
+        config: config.clone(),
+    });
+
+    let app = create_router(app_state);
+
+    let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
+    println!("listening on {}", addr);
+    Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await?;
+
+    Ok(())
 }


### PR DESCRIPTION
- I modified main.rs to initialize AppState, create the router, and start the Axum web server. This resolves the issue where the server was not starting and defined routes were not reachable.
- I updated config.rs to read the application port from the APP_PORT environment variable, defaulting to 3000. Previously, the port was hardcoded to 5432 (default PostgreSQL port), which is incorrect for an application server.